### PR TITLE
Add object count display and hide empty result tables

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,10 @@ uv run ruff check --fix .
 
 # Type checking (if needed - not currently configured)
 # uv run mypy .
+
+# Run Python scripts/modules
+uv run python script.py
+uv run python -m module_name
 ```
 
 ### Running the Application

--- a/launch_app.bash
+++ b/launch_app.bash
@@ -62,6 +62,7 @@ if [[ "$MODE" == "dev" ]]; then
     $PREFIX_OPT \
     --static-dirs "assets"="./assets" \
     --websocket-max-message-size $MAX_SIZE_BYTES \
+    --ico-path "none" \
     --dev
 else
   echo "Running in production mode with multi-threading"
@@ -76,6 +77,7 @@ else
     $PREFIX_OPT \
     --static-dirs "assets"="./assets" \
     --websocket-max-message-size $MAX_SIZE_BYTES \
+    --ico-path "none" \
     --num-threads 8
 fi
 


### PR DESCRIPTION
## Summary
- Add object count display above the Tabulator widget to show number of detected flux standard stars
- Hide the Tabulator table when no matches are found (only show count)
- Improve UI layout with increased table height for better visibility
- Update documentation with `uv run python` usage

## Changes
- **app.py**: Add `object_count_text` Markdown pane to display matched object count
- **app.py**: Conditionally show/hide Tabulator based on whether matches exist
- **app.py**: Increase table height from 640 to 720 pixels
- **launch_app.bash**: Add `--ico-path "none"` to suppress favicon warnings
- **CLAUDE.md**: Document `uv run python` command usage

## Test plan
- [x] Upload CSV file with objects that have flux standard matches
- [x] Verify count displays correctly above the table
- [x] Verify table shows when matches exist
- [x] Upload CSV with objects that have no matches
- [x] Verify count shows "Detected objects: 0"
- [x] Verify table is hidden when no matches found

🤖 Generated with [Claude Code](https://claude.com/claude-code)