### PR TITLE
Move launch_app.bash to scripts/ directory

### DIFF
--- a/scripts/launch_app.bash
+++ b/scripts/launch_app.bash
@@ -1,9 +1,10 @@
 #!/bin/bash
 set -eo pipefail
 
-# Change to script directory to ensure .env is found
+# Change to project root directory to ensure .env is found
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-cd "$SCRIPT_DIR"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$PROJECT_ROOT"
 
 # Load environment variables from .env file
 if [[ -f .env ]]; then


### PR DESCRIPTION
## Summary
- Relocated `launch_app.bash` from project root to `scripts/` directory for better organization
- Modified script to be location-independent by calculating project root relative to script location
- Script now works correctly when executed from either project root or scripts directory

## Changes
- Added `PROJECT_ROOT` variable that resolves to the parent directory of the script's location
- Updated `cd` command to use `PROJECT_ROOT` instead of `SCRIPT_DIR`
- Ensures `.env`, `app.py`, and `assets/` are always found regardless of execution location

## Test plan
- [x] Verify script runs correctly from project root: `./scripts/launch_app.bash`
- [x] Verify script runs correctly from scripts directory: `cd scripts && ./launch_app.bash`
- [x] Confirm `.env` file is loaded from project root in both cases
- [x] Confirm application starts successfully with correct paths to assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)