### PR TITLE
Remove unnecessary wheel build configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,10 +85,6 @@ convention = "numpy"
 # Keep tests lightweight: don't require docstrings in test files.
 "tests/**.py" = ["D"]
 
-[tool.hatch.build.targets.wheel]
-packages = ["."]
-only-include = ["app.py", "utils.py"]
-
 [tool.hatch.version]
 source = "vcs"
 tag-pattern = "^v(?P<version>.+)$"


### PR DESCRIPTION
## Summary

- Removed `[tool.hatch.build.targets.wheel]` section from pyproject.toml
- This configuration is unnecessary since the project runs scripts directly via `uv run` and `launch_app.bash`
- The removed configuration was also problematic (`packages = ["."]` is not appropriate for flat script-based projects)

## Test plan

- [x] Verify `uv sync` still works correctly
- [x] Verify `uv run` can execute scripts
- [x] Confirm no impact on existing functionality (app launch, dependency management)

🤖 Generated with [Claude Code](https://claude.com/claude-code)