### PR TITLE
Make primary color configurable via environment variable

### DIFF
--- a/app.py
+++ b/app.py
@@ -20,11 +20,18 @@ from utils import (
     process_fluxstd_lookup,
 )
 
-pn.extension("tabulator", notifications=True)
+load_dotenv()
+
+PRIMARY_COLOR = os.environ.get("PRIMARY_COLOR", "#5a79ba")
+pn.extension(
+    "tabulator",
+    design="material",
+    notifications=True,
+    global_css=[f":root {{ --design-primary-color: {PRIMARY_COLOR}; }}"],
+)
 
 logger.info("PFS Flux Standard Star Lookup Tool")
 
-load_dotenv()
 
 # Widgets
 file_input = pn.widgets.FileInput(
@@ -264,7 +271,7 @@ main = pn.Column(
 pn.template.MaterialTemplate(
     title="PFS Flux Standard Star Lookup",
     main=[main],
-    header_background="#5a79ba",
+    # header_background="#5a79ba",
     raw_css=[
         """
         /* Local Variable Fonts */


### PR DESCRIPTION
## Summary

- Adds `PRIMARY_COLOR` environment variable to make the application's primary color configurable
- Applies the color via CSS custom property `--design-primary-color` instead of hardcoded `header_background`
- Moves `load_dotenv()` before `pn.extension()` to ensure environment variables are loaded before use
- Defaults to `#5a79ba` if `PRIMARY_COLOR` is not set

## Test plan

- [ ] Set `PRIMARY_COLOR` in `.env` file to a custom color (e.g., `#ff0000`)
- [ ] Launch the application and verify the primary color matches the configured value
- [ ] Test without `PRIMARY_COLOR` set and verify it uses the default `#5a79ba`
- [ ] Verify UI components (header, buttons, links) properly use the custom color

🤖 Generated with [Claude Code](https://claude.com/claude-code)