### PR TITLE
Add PS1+Gaia and Gaia-only catalog source tracking

### DIFF
--- a/app.py
+++ b/app.py
@@ -81,6 +81,7 @@ result_table = pn.widgets.Tabulator(
         "fluxstd_ra": "fluxstd_RA (deg)",
         "fluxstd_dec": "fluxstd_Dec (deg)",
         "sep_arcsec": "separation (arcsec)",
+        "catalog_source": "catalog",
     },
     stylesheets=[
         """
@@ -179,6 +180,7 @@ def match_fluxstd_callback(event: Any) -> None:
                     "fluxstd_ra",
                     "fluxstd_dec",
                     "sep_arcsec",
+                    "catalog_source",
                 ],
             ]
             result_table.visible = True
@@ -204,6 +206,7 @@ def match_fluxstd_callback(event: Any) -> None:
                         "fluxstd_ra",
                         "fluxstd_dec",
                         "sep_arcsec",
+                        "catalog_source",
                     ],
                 ]
                 .to_csv(index=False)


### PR DESCRIPTION
## Summary
Implement dual catalog support to prioritize PS1+Gaia flux standards while using Gaia-only as fallback for regions without PS1 coverage (Dec < -30).

## Changes
- **Dual catalog processing**: Process both PS1+Gaia and Gaia-only flux standards, combining with OR operation
- **Catalog source tracking**: Add `catalog_source` column to distinguish "PS1+Gaia" vs "Gaia-only" sources
- **Index type fixes**: Fix numpy array indexing errors in `match_catalog()` by explicit int conversion
- **UI updates**: Display catalog source in web table and include in CSV downloads
- **Enhanced logging**: Show PS1+Gaia and Gaia-only counts separately

## Technical Details
- Modified `generate_fluxstd_coords()` to return 3-tuple including `catalog_source` Series
- Updated `match_catalog()` to propagate catalog source to output DataFrame
- Fixed dtype incompatibility by using OR operation instead of conditional assignment
- Added catalog_source column to Tabulator widget with title "catalog"

## Test plan
- [x] Verify no indexing errors occur during matching
- [x] Confirm catalog_source column appears in web UI
- [x] Check CSV downloads include catalog_source
- [x] Validate PS1+Gaia and Gaia-only counts in logs
- [x] Test with data including both PS1 and Gaia-only regions

🤖 Generated with [Claude Code](https://claude.com/claude-code)